### PR TITLE
added in the ability to use a profile for aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ The Dev Tools for the Serverless World
 # To Run
 
 - `npm install -g sls-dev-tools`
-- Run `sls-dev-tools -n {YOUR_STACK_NAME} -r {YOUR_REGION} [-t {START_TIME}] [-p {PERIOD}]`
+- Run `sls-dev-tools -n {YOUR_STACK_NAME} -r {YOUR_REGION} [-t {START_TIME}] [-i {INTERVAL}] [-p {PROFILE}]`
   - The start time defines when you want your graphs to start from, and the date format for the start time is `YYYY-MM-DD/HH:mm`
-  - The period defines the size of the buckets in seconds. This means if you give a period of 3600, the line graph will group the invocations and errors into 1h chunks, and the bar chart will show the average response time over the hour for the last 6 hours during which invocations were made.
+  - The interval defines the size of the buckets in seconds. This means if you give a interval of 3600, the line graph will group the invocations and errors into 1h chunks, and the bar chart will show the average response time over the hour for the last 6 hours during which invocations were made.
   - To get the stack name, log on to AWS cloudformation and it is shown in the overview section of stack info. It may not be what you expected e.g. it might have `-dev` on the end, so worth checking if the dev tools are not working.
   - The region is the AWS region, for example, us-east-1.
 - Choose a function with the arrow keys, and press enter to see the metrics for that function.
   - If you get an `AccessDenied` error in which case you must add the `GetMetricData` permission from CloudWatch in the IAM console on AWS.
   - If you're not seeing any data in the graphs, try changing your start date to make sure you have had invocations since then.
-- The line graph shows the number of invocations and errors that occurred within the time period.
-- The bar chart shows the average response time of the invocations within the last 6 time periods that had some invocations.
+- The line graph shows the number of invocations and errors that occurred within the time interval.
+- The bar chart shows the average response time of the invocations within the last 6 time intervals that had some invocations.
 
 ```
 Options:
@@ -27,7 +27,8 @@ Options:
   -n, --stack-name <stackName>  AWS stack name
   -r, --region <region>         AWS region
   -t, --start-time <startTime>  when to start from
-  -p, --period <period>         precision of graphs, in seconds
+  -i, --interval <interval>     interval of graphs, in seconds
+  -p, --profile <profile>       aws profile name to use
   -h, --help                    output usage information
 ```
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-plusplus */
 /* eslint-disable no-console */
 /* eslint-disable new-cap */
-
 import AWS from 'aws-sdk';
 import { awsRegionLocations, logo, dateFormats } from './constants';
 
@@ -17,15 +16,13 @@ program
   .option('-r, --region <region>', 'AWS region')
   .option('-t, --start-time <startTime>', 'when to start from')
   .option('-i, --interval <interval>', 'interval of graphs, in seconds')
-  .option('-p, --profile <profile>', 'aws profile name to use')
+  .option('-p, --period <period>', 'precision of graphs, in seconds')
   .parse(process.argv);
 
 const screen = blessed.screen({ smartCSR: true });
-const profile = program.profile || 'default'
-const credentials = new AWS.SharedIniFileCredentials({ profile: profile });
-const cloudformation = new AWS.CloudFormation({ region: program.region, credentials: credentials });
-const cloudwatch = new AWS.CloudWatch({ region: program.region, credentials: credentials });
-const cloudwatchLogs = new AWS.CloudWatchLogs({ region: program.region, credentials: credentials });
+const cloudformation = new AWS.CloudFormation({ region: program.region });
+const cloudwatch = new AWS.CloudWatch({ region: program.region });
+const cloudwatchLogs = new AWS.CloudWatchLogs({ region: program.region });
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -102,7 +99,7 @@ class Main {
 
     this.funcName = null;
 
-    this.interval = program.interval || 3600; // 1 hour
+    this.period = program.period || 3600; // 1 hour
     this.endTime = new Date();
     if (program.startTime) {
       // eslint-disable-next-line prefer-destructuring
@@ -110,9 +107,9 @@ class Main {
     } else {
       const dateOffset = (24 * 60 * 60 * 1000); // 1 day
 
-      // Round to closest interval to make query faster.
+      // Round to closest period to make query faster.
       this.startTime = new Date(
-        (Math.round(new Date().getTime() / this.interval) * this.interval) - dateOffset,
+        (Math.round(new Date().getTime() / this.period) * this.period) - dateOffset,
       );
     }
   }
@@ -182,7 +179,7 @@ class Main {
       for (
         let timestamp = moment(this.startTime).valueOf();
         timestamp < moment(this.endTime).valueOf();
-        timestamp = moment(timestamp).add(this.interval, 'seconds').valueOf()
+        timestamp = moment(timestamp).add(this.period, 'seconds').valueOf()
       ) {
         if (this.data.MetricDataResults[index].Timestamps.every(
           (it) => it.valueOf() !== timestamp,
@@ -219,7 +216,7 @@ class Main {
       style: { line: 'green' },
       x: this.data.MetricDataResults[2].Timestamps.map((d) => {
         const start = moment(d).format(dateFormat);
-        const end = moment(d).add(this.interval, 'seconds').format(dateFormat);
+        const end = moment(d).add(this.period, 'seconds').format(dateFormat);
         return `${start}-${end}`;
       }),
       y: this.data.MetricDataResults[2].Values,
@@ -318,7 +315,7 @@ class Main {
               MetricName: 'Duration',
               Namespace: 'AWS/Lambda',
             },
-            Period: this.interval,
+            Period: this.period,
             Stat: 'Maximum',
           },
           ReturnData: true,
@@ -340,7 +337,7 @@ class Main {
               MetricName: 'Errors',
               Namespace: 'AWS/Lambda',
             },
-            Period: this.interval,
+            Period: this.period,
             Stat: 'Sum',
           },
           ReturnData: true,
@@ -362,7 +359,7 @@ class Main {
               MetricName: 'Invocations',
               Namespace: 'AWS/Lambda',
             },
-            Period: this.interval,
+            Period: this.period,
             Stat: 'Sum',
           },
           ReturnData: true,


### PR DESCRIPTION
Added in the option to use a profile that is in your aws credentials file, using -p or --profile 
Renamed the option for period to interval and the flags to -i & --interval