### PR TITLE
Open help modal when h is pressed & pipe all console.logs and errors to log a component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
 
 ```
 Shortcuts
+- Pressing "h" while the tool is open will display a helpbox with all the keybindings and cli options.
 - Pressing "o" while selecting a function from the function list will open the relevant page of the AWS console (saving some clicks!)
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 /* eslint-disable new-cap */
 import AWS from 'aws-sdk';
 import { awsRegionLocations, logo, dateFormats } from './constants';
+import { helpModal } from './modals';
 
 const blessed = require('blessed');
 const contrib = require('blessed-contrib');
@@ -117,7 +118,7 @@ class Main {
         },
       },
     });
-    screen.key(['escape', 'q', 'C-c'], () => process.exit(0));
+    screen.key(['q', 'C-c'], () => process.exit(0));
     // fixes https://github.com/yaronn/blessed-contrib/issues/10
     screen.key(['o', 'O'], () => {
       const selectedLambdaFunctionName = this.table.rows.items[
@@ -127,6 +128,7 @@ class Main {
         `https://${program.region}.console.aws.amazon.com/lambda/home?region=${program.region}#/functions/${selectedLambdaFunctionName}?tab=configuration`,
       );
     });
+    screen.key(['h', 'H'], () => helpModal(screen, blessed));
     screen.on('resize', () => {
       this.bar.emit('attach');
       this.table.emit('attach');

--- a/index.js
+++ b/index.js
@@ -89,12 +89,20 @@ class Main {
       },
     });
     this.eventBridgeTree.rows.interactive = false;
-    this.log = this.grid.set(8, 0, 4, 9, blessed.log, {
+    this.lambdaLog = this.grid.set(8, 0, 4, 6, blessed.log, {
       fg: 'green',
       selectedFg: 'green',
       label: 'Server Log',
       interactive: true,
       scrollbar: { bg: 'blue' },
+      mouse: true,
+    });
+    this.consoleLogs = this.grid.set(8, 6, 4, 3, blessed.log, {
+      fg: 'red',
+      selectedFg: 'dark-red',
+      label: 'Dashboard Logs',
+      interactive: true,
+      scrollbar: { bg: 'red' },
       mouse: true,
     });
     this.titleBox = this.grid.set(0, 0, 2, 6, blessed.box, {
@@ -126,7 +134,8 @@ class Main {
       this.titleBox.emit('attach');
       this.invocationsLineGraph.emit('attach');
       this.map.emit('attach');
-      this.log.emit('attach');
+      this.lambdaLog.emit('attach');
+      this.consoleLogs.emit('attach');
     });
     screen.title = 'sls-dev-tools';
     this.marker = false;
@@ -147,6 +156,11 @@ class Main {
           - dateOffset,
       );
     }
+
+    global.console = {
+      log: (m) => this.consoleLogs.log(m),
+      error: (m) => this.consoleLogs.log(m),
+    };
   }
 
   async render() {
@@ -331,7 +345,7 @@ class Main {
 
   getLogEvents(logGroupName, logStreamNames) {
     if (logStreamNames.length === 0) {
-      this.log.setContent('ERROR: No log streams found for this function.');
+      this.lambdaLog.setContent('ERROR: No log streams found for this function.');
       return;
     }
     const params = {
@@ -346,9 +360,9 @@ class Main {
       .then(
         (data) => {
           const { events } = data;
-          this.log.setContent('');
+          this.lambdaLog.setContent('');
           events.forEach((event) => {
-            this.log.log(event.message);
+            this.lambdaLog.log(event.message);
           });
         },
         (err) => {

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ class Main {
       tags: true,
       content:
         `${logo}\n Dev Tools for the Serverless World.`
-        + '\n    - Select a function from the list on the right',
+        + '    Press `h` for help',
       style: {
         fg: 'green',
         border: {

--- a/modals.js
+++ b/modals.js
@@ -1,0 +1,66 @@
+const helpModal = (screen, blessed) => {
+  const helpMenuData = [
+    ['Keybinding', 'Action'],
+    ['-----------', '-----------'],
+    ['Enter', 'Displays function data when focused on Functions table'],
+    ['O or o', 'Opens the AWS console for a selected lambda function'],
+    ['q or Q', 'Close the application'],
+    ['Arrows', 'Used to select from list, by default the function list'],
+  ];
+  const cliOptionsData = [
+    ['---------', '----------'],
+    ['CLI Option', 'Description'],
+    ['---------', '----------'],
+    ['-V, --version', 'output the version number'],
+    ['-n, --stack-name <stackName>', 'AWS stack name'],
+    ['-r, --region <region>', 'AWS region'],
+    ['-t, --start-time <startTime>', 'when to start from'],
+    ['-i, --interval <interval>', 'interval of graphs, in seconds'],
+    ['-p, --profile <profile>', 'aws profile name to use'],
+    ['-h, --help', 'output usage information'],
+  ];
+  const helpLayout = blessed.layout({
+    parent: screen,
+    top: 'center',
+    left: 'center',
+    width: 112,
+    height: 27,
+    border: 'line',
+    style: { border: { fg: 'green' } },
+  });
+  blessed.listtable({
+    parent: helpLayout,
+    interactive: false,
+    top: 'center',
+    left: 'center',
+    data: [...helpMenuData, ...cliOptionsData],
+    border: 'line',
+    pad: 2,
+    width: 110,
+    height: 20,
+    style: {
+      border: { fg: 'green' },
+      header: { fg: 'bright-green', bold: true, underline: true },
+      cell: { fg: 'yellow' },
+    },
+  });
+  blessed.box({
+    parent: helpLayout,
+    width: 110,
+    height: 4,
+    left: 'right',
+    top: 'center',
+    align: 'center',
+    padding: { left: 2, right: 2 },
+    border: 'line',
+    style: { fg: 'green', border: { fg: 'green' } },
+    content: 'Please give feedback via GitHub Issues \n ESC to close',
+  });
+  screen.key(['escape'], () => {
+    helpLayout.destroy();
+  });
+};
+
+module.exports = {
+  helpModal,
+};

--- a/modals.js
+++ b/modals.js
@@ -4,7 +4,7 @@ const helpModal = (screen, blessed) => {
     ['-----------', '-----------'],
     ['Enter', 'Displays function data when focused on Functions table'],
     ['O or o', 'Opens the AWS console for a selected lambda function'],
-    ['q or Q', 'Close the application'],
+    ['Q or q', 'Close the application'],
     ['Arrows', 'Used to select from list, by default the function list'],
   ];
   const cliOptionsData = [

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "eslint-plugin-import": "^2.18.2"
   },
   "scripts": {
-    "build": "babel index.js constants.js --out-dir lib",
-    "dev": "babel index.js constants.js --out-dir lib --watch",
+    "build": "babel index.js constants.js modals.js --out-dir lib",
+    "dev": "babel index.js constants.js modals.js --out-dir lib --watch",
     "start": "node ./lib/index.js"
   },
   "babel": {


### PR DESCRIPTION
- Pressing h will open a new modal with keybindings and cli options - also demonstrates how we can use models and handle more complex layouts
- console errors and logs are hard to read when presented in default location. These have been moved into a dedicated log stream.