### PR TITLE
Fix default stack name for serverless framework

### DIFF
--- a/src/services/serverless.js
+++ b/src/services/serverless.js
@@ -31,7 +31,10 @@ class Serverless {
     ) {
       return `${this.config.provider.stackName}`;
     }
-    return `${this.config.service}-${stage}`;
+    if (typeof this.config.service === "string") {
+      return `${this.config.service}-${stage}`;
+    }
+    return `${this.config.service.name}-${stage}`;
   }
 
   getRegion() {

--- a/src/services/serverless.js
+++ b/src/services/serverless.js
@@ -31,7 +31,7 @@ class Serverless {
     ) {
       return `${this.config.provider.stackName}`;
     }
-    return `${this.config.service.name}-${stage}`;
+    return `${this.config.service}-${stage}`;
   }
 
   getRegion() {


### PR DESCRIPTION
Fixes #161

For some in my first PR I had that wrong key for stack name. In my local version that I use otherwise I had this correctly set.