### PR TITLE
Exit program on SharedIniFileCredentials fail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 import AWS from "aws-sdk";
-import { logo, dateFormats, DASHBOARD_FOCUS_INDEX } from "./constants";
+import {
+  awsRegionLocations,
+  logo,
+  dateFormats,
+  DASHBOARD_FOCUS_INDEX,
+} from "./constants";
 import {
   eventRegistryModal,
   eventInjectionModal,
@@ -20,7 +25,6 @@ import {
   checkLogsForErrors,
 } from "./services/processEventLogs";
 import { getLogEvents } from "./services/awsCloudwatchLogs";
-
 import checkForUpdates from "./utils/updateNotifier";
 
 const blessed = require("blessed");
@@ -562,7 +566,11 @@ function startTool() {
       AWS.config.credentials = creds;
       updateAWSServices();
 
-      if (!program.region) {
+      if (
+        !awsRegionLocations
+          .map((region) => region.label)
+          .includes(program.region)
+      ) {
         promptRegion();
       } else if (!program.stackName) {
         promptStackName();

--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ function getAWSCredentials() {
       callback: (err) => {
         if (err) {
           console.error(`SharedIniFileCreds Error: ${err}`);
+          process.exit(0);
         }
       },
     });
@@ -122,6 +123,7 @@ function getAWSCredentials() {
       callback: (err) => {
         if (err) {
           console.error(`SharedIniFileCreds Error: ${err}`);
+          process.exit(0);
         }
       },
     });
@@ -371,6 +373,7 @@ class Main {
 
   async render() {
     setInterval(() => {
+      console.log(process.memoryUsage());
       this.map.updateMap();
       this.updateResourcesInformation();
       this.updateGraphs();


### PR DESCRIPTION
Previously program would get stuck on a black screen if profile was malformed (e.g. profile didn't exist)