### PR TITLE
Allow users to switch between relay on different functions

### DIFF
--- a/src/CLIMain.js
+++ b/src/CLIMain.js
@@ -10,6 +10,7 @@ import { Map, Log, DurationBarChart, ResourceTable } from "./components";
 import { getLambdaMetrics } from "./services/lambdaMetrics";
 import {
   updateLogContentsFromEvents,
+  updateLogContentsFromRelay,
   checkLogsForErrors,
 } from "./services/processEventLogs";
 import { getLogEvents } from "./services/awsCloudwatchLogs";
@@ -169,11 +170,13 @@ class Main {
     this.notifier = new blessed.Program();
 
     // Monitor active relay layers
-    this.relayActive = false;
+    this.relayActive = {};
     // Allow the user the quit after receiving a warning
     this.warningGiven = false;
     // Store of relay api ids
     this.relayApis = {};
+    // Store messages received from relay per function
+    this.relayLogs = {};
 
     checkForUpdates();
 
@@ -280,7 +283,7 @@ class Main {
     // Overwrite quit keybinds to perform safety checks
     this.screen.unkey(["q", "C-c"]);
     this.screen.key(["q", "C-c"], () => {
-      if (this.relayActive && !this.warningGiven) {
+      if (this.isRelayActive() && !this.warningGiven) {
         disableRelayWarningModal(this.screen, this);
       } else {
         process.exit(0);
@@ -378,8 +381,15 @@ class Main {
     this.prevError = value;
   }
 
-  setRelayActive(value) {
-    this.relayActive = value;
+  setRelayActive(lambda, value) {
+    this.relayActive[lambda] = value;
+  }
+
+  isRelayActive() {
+    if (Object.values(this.relayActive).indexOf(true) > -1) {
+      return true;
+    }
+    return false;
   }
 
   setWarningGiven(value) {
@@ -411,8 +421,13 @@ class Main {
         this.cloudwatchLogs
       ).then((data) => {
         this.events = data;
-        if (!this.relayActive) {
+        if (!this.relayActive[this.resourceTable.fullFuncName]) {
           updateLogContentsFromEvents(this.lambdaLog.datalog, this.events);
+        } else {
+          updateLogContentsFromRelay(
+            this.lambdaLog.datalog,
+            this.relayLogs[this.resourceTable.fullFuncName]
+          );
         }
         if (data) {
           checkLogsForErrors(this.events, this);

--- a/src/CLIMain.js
+++ b/src/CLIMain.js
@@ -386,7 +386,7 @@ class Main {
   }
 
   isRelayActive() {
-    if (Object.values(this.relayActive).indexOf(true) > -1) {
+    if (Object.values(this.relayActive).includes(true)) {
       return true;
     }
     return false;

--- a/src/components/resourceTable.js
+++ b/src/components/resourceTable.js
@@ -47,7 +47,7 @@ class ResourceTable {
     this.fullFuncName = null;
     this.table.rows.on("select", (item) => {
       if (item.data[0] === this.funcName) {
-        if (!application.relayActive) {
+        if (!application.relayActive[this.fullFuncName]) {
           if (item.data[4].substring(0, 6) === "nodejs") {
             relayModal(
               this.screen,

--- a/src/services/processEventLogs.js
+++ b/src/services/processEventLogs.js
@@ -9,6 +9,17 @@ function updateLogContentsFromEvents(log, events) {
   }
 }
 
+function updateLogContentsFromRelay(log, events) {
+  if (events) {
+    log.setContent("");
+    events.forEach((event) => {
+      log.log(event);
+    });
+  } else {
+    log.setContent("No Relay logs for this function this session");
+  }
+}
+
 function checkLogsForErrors(events, application) {
   let logId = "";
   if (events.length > 0) {
@@ -39,5 +50,6 @@ function checkLogsForErrors(events, application) {
 
 module.exports = {
   updateLogContentsFromEvents,
+  updateLogContentsFromRelay,
   checkLogsForErrors,
 };

--- a/src/services/relay.js
+++ b/src/services/relay.js
@@ -34,12 +34,13 @@ async function createRelay(
     const relay = new WebSocket(websocketAddress);
     relay.on("open", () => {
       console.log("Warning: Realtime logs will appear faster than CloudWatch");
-      application.setRelayActive(true);
-      // Clear and reset logs
-      application.lambdaLog.generateLog();
+      application.setRelayActive(fullLambda.FunctionName, true);
     });
     relay.on("message", (data) => {
-      application.lambdaLog.log(data);
+      if (!application.relayLogs[fullLambda.FunctionName]) {
+        application.relayLogs[fullLambda.FunctionName] = [];
+      }
+      application.relayLogs[fullLambda.FunctionName].push(data);
     });
     relay.on("close", () => {
       console.log("Relay Closed");
@@ -72,7 +73,7 @@ async function takedownRelay(
     await removeLambdaLayer(lambda, fullLambda);
     await removeRelayPermissions(lambda, iam, fullLambda);
     console.log("Relay Successfully Disabled");
-    application.setRelayActive(false);
+    application.setRelayActive(fullLambda.FunctionName, false);
   } catch (e) {
     console.error("Relay Takedown Failure");
     console.error(e);


### PR DESCRIPTION
Changed logic for detecting whether or not relay is active (function specific as opposed to general) and added relayLog stores so that switching between different functions on relay/turning relay on and off doesn't clear previously logged relay messages for the current session