### PR TITLE
Feature/133 fullscreen logs

### DIFF
--- a/src/CLIMain.js
+++ b/src/CLIMain.js
@@ -23,6 +23,7 @@ import {
   regionWizardModal,
   stackWizardModal,
   disableRelayWarningModal,
+  expandedLogModal,
 } from "./modals";
 
 const blessed = require("blessed");
@@ -152,6 +153,7 @@ class Main {
       this.resourceTable.table,
       this.eventBridgeTree,
       this.map.map,
+      this.lambdaLog,
     ];
     this.resourceTable.table.focus();
     this.returnFocus();
@@ -379,6 +381,17 @@ class Main {
         );
       }
       return 0;
+    });
+
+    this.screen.key(["m"], () => {
+      if (this.isModalOpen === false) {
+        expandedLogModal(
+          this.screen,
+          this,
+          "Dashboard Logs",
+          this.lambdaLog.datalog.content
+        );
+      }
     });
   }
 

--- a/src/components/scrollableBox.js
+++ b/src/components/scrollableBox.js
@@ -1,0 +1,24 @@
+const blessed = require("blessed");
+
+class ScrollableBox extends blessed.box {
+  constructor(parent, width, height, content) {
+    super({
+      parent,
+      width,
+      height,
+      left: "right",
+      top: "center",
+      padding: { left: 2, right: 2 },
+      border: "bg",
+      style: { fg: "green" },
+      content,
+      scrollable: true,
+      alwaysScroll: true,
+      mouse: true,
+    });
+  }
+}
+
+module.exports = {
+  ScrollableBox,
+};

--- a/src/modals/expandedLogModal.js
+++ b/src/modals/expandedLogModal.js
@@ -14,11 +14,22 @@ const expandedLogModal = (screen, application, title, content) => {
     screen.program.enableMouse();
   };
 
-  new ModalTitle(expandedLogLayout, "100%", title);
+  // Whether user can scroll the logs or click and drag to select text
+  let canScroll = false;
+
+  const modalTitle = new ModalTitle(expandedLogLayout, "100%", "");
+
+  modalTitle.style = { fg: "yellow" };
+  modalTitle.content = `${title}`;
 
   const logBox = new ScrollableBox(expandedLogLayout, "100%", "89%", content);
 
-  new Box(expandedLogLayout, "99%", 4, "ESC to close");
+  new Box(
+    expandedLogLayout,
+    "99%",
+    4,
+    "ESC to close || t to toggle between text selection and scrolling"
+  );
 
   logBox.focus();
 
@@ -27,8 +38,19 @@ const expandedLogModal = (screen, application, title, content) => {
     closeModal();
   });
 
-  // Enables text selection, but disables scrolling
-  // screen.program.disableMouse();
+  logBox.key(["t"], () => {
+    if (canScroll) {
+      // Enables text selection, but disables scrolling
+      screen.program.disableMouse();
+      canScroll = false;
+      modalTitle.content = `${title} - SELECTABLE`;
+    } else {
+      // Enables scrolling, but disables text selection
+      screen.program.enableMouse();
+      canScroll = true;
+      modalTitle.content = `${title} - SCROLLABLE`;
+    }
+  });
 };
 
 module.exports = {

--- a/src/modals/expandedLogModal.js
+++ b/src/modals/expandedLogModal.js
@@ -1,0 +1,36 @@
+import { Box } from "../components/box";
+import { ScrollableBox } from "../components/scrollableBox";
+import { ModalLayout } from "../components/modalLayout";
+import { ModalTitle } from "../components/modalTitle";
+
+const expandedLogModal = (screen, application, title, content) => {
+  const expandedLogLayout = new ModalLayout(screen, "100%", "100%", true);
+  expandedLogLayout.border = "bg";
+
+  const closeModal = () => {
+    application.setIsModalOpen(false);
+    application.returnFocus();
+    expandedLogLayout.destroy();
+    screen.program.enableMouse();
+  };
+
+  new ModalTitle(expandedLogLayout, "100%", title);
+
+  const logBox = new ScrollableBox(expandedLogLayout, "100%", "89%", content);
+
+  new Box(expandedLogLayout, "99%", 4, "ESC to close");
+
+  logBox.focus();
+
+  logBox.key(["escape"], () => {
+    // Discard modal
+    closeModal();
+  });
+
+  // Enables text selection, but disables scrolling
+  // screen.program.disableMouse();
+};
+
+module.exports = {
+  expandedLogModal,
+};

--- a/src/modals/index.js
+++ b/src/modals/index.js
@@ -12,3 +12,4 @@ export { relayModal } from "./relayModal";
 export { errorModal } from "./errorModal";
 export { disableRelayModal } from "./disableRelayModal";
 export { disableRelayWarningModal } from "./disableRelayWarningModal";
+export { expandedLogModal } from "./expandedLogModal";


### PR DESCRIPTION
Couldn't find option in blessed that would simultaneously support scrolling and click and drag text selection. 

- Open fullscreen logs on keypress (currently pressing m) and allow text selection by default. 
- Option to press t to toggle between scrolling and selection.

<img width="1424" alt="Screenshot 2020-05-19 at 16 06 07" src="https://user-images.githubusercontent.com/28564974/82343613-fdf04380-99ea-11ea-9384-e3cfcf8555be.png">
<img width="293" alt="Screenshot 2020-05-19 at 16 06 22" src="https://user-images.githubusercontent.com/28564974/82343620-ffba0700-99ea-11ea-9384-a8db22df2f4f.png">
<img width="246" alt="Screenshot 2020-05-19 at 16 06 26" src="https://user-images.githubusercontent.com/28564974/82343628-00eb3400-99eb-11ea-9b28-59c5d25af0d1.png">

