### PR TITLE
Added VS code debug support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,4 @@ website
 img
 docs
 *.js.map
-lib/**/*.js
+lib/**/*.js.map

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 website
 img
 docs
+*.js.map
+lib/**/*.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/lib/**/*.js"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ Heavily based off the amazing [blessed](https://github.com/chjj/blessed) and [bl
 
 sls-dev-tools has a predefined debug configuration for Visual Studio Code. If you would like to use this, please follow these steps after cloning the repository:
 
-1. Build the project with source maps using `yarn build-maps`
-2. Start a node debugger instance for the project using <code>yarn debug -p _your-profile_</code>
+1. Build the project with source maps using `yarn build-maps`.
+2. Run the project with a node debugger attached using `yarn debug` plus any options that you would provide to the sls-dev-tools command.
 3. Navigate to VS Code's debug side panel, ensure that the 'Attach' configuration is selected in the dropdown next to the green 'Run' arrow.
 4. Press the green 'Run' arrow.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/Theodo-UK/sls-dev-tools.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Theodo-UK/sls-dev-tools/context:javascript)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 The Developer Tools for the Serverless World - think Chrome Dev Tools but for Serverless.
@@ -64,6 +66,10 @@ sls-dev-tools is currently being actively maintained. If you find a problem with
 
 [A note on AWS API calls and pricing](#a-note-on-aws-api-calls-and-pricing)\
 [Libs](#libs)\
+[Contributing to the Project](#contributing-to-the-project)
+
+- [Debugging](#debugging)
+
 [Contributors ✨](#contributors-)
 
 ## Installation
@@ -265,17 +271,30 @@ The current list of calls made by the tool:
 
 This tool needs these permissions to execute the features.
 
-| Action | Features |
-|:--| :-- |
-| `lambda:ListFunctions` | View, Guardian |
-| `cloudwatch:GetMetricData` | View |
-| `logs:DescribeLogStreams` | View |
-| `logs:FilterLogEvents` | View |
-| `events:ListEventBuses` | View |
+| Action                     | Features       |
+| :------------------------- | :------------- |
+| `lambda:ListFunctions`     | View, Guardian |
+| `cloudwatch:GetMetricData` | View           |
+| `logs:DescribeLogStreams`  | View           |
+| `logs:FilterLogEvents`     | View           |
+| `events:ListEventBuses`    | View           |
 
 # Libs
 
 Heavily based off the amazing [blessed](https://github.com/chjj/blessed) and [blessed-contrib](https://github.com/yaronn/blessed-contrib) projects.
+
+## Contributing to the Project
+
+### Debugging
+
+sls-dev-tools has a predefined debug configuration for Visual Studio Code. If you would like to use this, please follow these steps after cloning the repository:
+
+1. Build the project with source maps using `yarn build-maps`
+2. Start a node debugger instance for the project using <code>yarn debug -p _your-profile_</code>
+3. Navigate to VS Code's debug side panel, ensure that the 'Attach' configuration is selected in the dropdown next to the green 'Run' arrow.
+4. Press the green 'Run' arrow.
+
+Now you can add breakpoints throughout the source code and debug using VS Code's extensive debugging features.
 
 ## Contributors ✨
 
@@ -304,6 +323,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   },
   "scripts": {
     "build": "babel ./src --out-dir lib",
+    "build-maps": "babel ./src --out-dir lib --source-maps",
     "dev": "babel ./src --out-dir lib --watch",
     "start": "node ./lib/index.js",
+    "debug": "node --nolazy --inspect-brk=9229 ./lib/index.js",
     "lint": "eslint ./src",
     "fix": "yarn lint --fix",
     "test": "yarn lint",


### PR DESCRIPTION
Can now build the project with `yarn build-maps` and debug with `yarn debug`, attaching VS code's debugger